### PR TITLE
build: bump UBW to 0.15.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "rule-34-api",
       "version": "0.0.1",
       "dependencies": {
-        "@alejandroakbal/universal-booru-wrapper": "^0.15.21",
+        "@alejandroakbal/universal-booru-wrapper": "^0.15.22",
         "@fastify/helmet": "^11.1.1",
         "@fastify/static": "^6.12.0",
         "@nestjs/common": "^10.4.20",
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@alejandroakbal/universal-booru-wrapper": {
-      "version": "0.15.21",
-      "resolved": "https://npm.pkg.github.com/download/@AlejandroAkbal/universal-booru-wrapper/0.15.21/1bf43933e9453a9521231061f5c045d9278be066",
-      "integrity": "sha512-hU3M1vNFdGLPTWlD2/Fv/kKTq/anFflM9bQBr6/A78Hm74pZMJVywGGo7nLF/xEHsyC6Mnqeb6rldhkOiP5C7A==",
+      "version": "0.15.22",
+      "resolved": "https://npm.pkg.github.com/download/@AlejandroAkbal/universal-booru-wrapper/0.15.22/147a99e5e2d6aa2b73d67607e15e798197589ce8",
+      "integrity": "sha512-hnFiI588imYdue/56/PahA+NtE3e12hW05nluQ+l2BzP4PvwBguvVhJwUK0OOQzdSasO2UIEjjwOeSlpt2jlWA==",
       "license": "ISC",
       "dependencies": {
         "camaro": "^6.2.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     }
   },
   "dependencies": {
-    "@alejandroakbal/universal-booru-wrapper": "^0.15.21",
+    "@alejandroakbal/universal-booru-wrapper": "^0.15.22",
     "@fastify/helmet": "^11.1.1",
     "@fastify/static": "^6.12.0",
     "@nestjs/common": "^10.4.20",


### PR DESCRIPTION
## Summary
- bump `@alejandroakbal/universal-booru-wrapper` from `^0.15.21` to `^0.15.22`
- refresh `package-lock.json` to the newly published GitHub Packages artifact
- pick up the merged UBW HTML entity decode simplification from PR #7

## Validation
- `pnpm test -- booru/dto/booru-queries.dto.spec.ts booru/services/booru-auth-manager.service.spec.ts booru/booru.service.spec.ts --runInBand`
- `pnpm exec tsc --noEmit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to maintain compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->