### PR TITLE
add kemono booru type compatibility

### DIFF
--- a/src/booru/booru.service.spec.ts
+++ b/src/booru/booru.service.spec.ts
@@ -3,7 +3,7 @@ import { ConfigService } from '@nestjs/config'
 import { BooruTypesStringEnum } from '@alejandroakbal/universal-booru-wrapper'
 import { BooruService } from './booru.service'
 import { booruQueriesDTO } from './dto/booru-queries.dto'
-import { BooruEndpointParamsDTO } from './dto/request-booru.dto'
+import { BooruEndpointParamsDTO, SupportedBooruType } from './dto/request-booru.dto'
 import { BooruAuthManagerService } from './services/booru-auth-manager.service'
 
 describe('BooruService', () => {
@@ -122,5 +122,31 @@ describe('BooruService', () => {
     })
 
 
+  })
+
+  describe('Booru type resolution', () => {
+    it('should resolve kemono when supported and fail clearly otherwise', () => {
+      const maybeKemonoClass = (require('@alejandroakbal/universal-booru-wrapper') as any).Kemono
+
+      const params: BooruEndpointParamsDTO = {
+        booruType: 'kemono' as SupportedBooruType
+      }
+
+      const queries = {
+        baseEndpoint: 'kemono.cr'
+      } as booruQueriesDTO
+
+      if (maybeKemonoClass) {
+        const api = service.buildApiClass(params, queries)
+
+        expect(api).toBeInstanceOf(maybeKemonoClass)
+
+        return
+      }
+
+      expect(() => service.buildApiClass(params, queries)).toThrow(
+        'Kemono booru type requires @alejandroakbal/universal-booru-wrapper version that exports Kemono'
+      )
+    })
   })
 })

--- a/src/booru/booru.service.spec.ts
+++ b/src/booru/booru.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { ConfigService } from '@nestjs/config'
 import { BooruTypesStringEnum } from '@alejandroakbal/universal-booru-wrapper'
+import * as UBW from '@alejandroakbal/universal-booru-wrapper'
 import { BooruService } from './booru.service'
 import { booruQueriesDTO } from './dto/booru-queries.dto'
 import { BooruEndpointParamsDTO, SupportedBooruType } from './dto/request-booru.dto'
@@ -125,23 +126,37 @@ describe('BooruService', () => {
   })
 
   describe('Booru type resolution', () => {
-    it('should resolve kemono when supported and fail clearly otherwise', () => {
-      const maybeKemonoClass = (require('@alejandroakbal/universal-booru-wrapper') as any).Kemono
+    const queries = {
+      baseEndpoint: 'kemono.cr'
+    } as booruQueriesDTO
+
+    afterEach(() => {
+      if ((UBW as any).Kemono !== originalKemonoClass) {
+        ;(UBW as any).Kemono = originalKemonoClass
+      }
+    })
+
+    const originalKemonoClass = (UBW as any).Kemono
+
+    it('should resolve kemono when the wrapper exports it', () => {
+      if (!originalKemonoClass) {
+        return
+      }
 
       const params: BooruEndpointParamsDTO = {
         booruType: 'kemono' as SupportedBooruType
       }
 
-      const queries = {
-        baseEndpoint: 'kemono.cr'
-      } as booruQueriesDTO
+      const api = service.buildApiClass(params, queries)
 
-      if (maybeKemonoClass) {
-        const api = service.buildApiClass(params, queries)
+      expect(api).toBeInstanceOf(originalKemonoClass)
+    })
 
-        expect(api).toBeInstanceOf(maybeKemonoClass)
+    it('should fail clearly when the wrapper does not export kemono', () => {
+      ;(UBW as any).Kemono = undefined
 
-        return
+      const params: BooruEndpointParamsDTO = {
+        booruType: 'kemono' as SupportedBooruType
       }
 
       expect(() => service.buildApiClass(params, queries)).toThrow(

--- a/src/booru/booru.service.ts
+++ b/src/booru/booru.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common'
+import { BadRequestException, Injectable, ServiceUnavailableException } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import {
   BooruTypes,
@@ -146,13 +146,16 @@ export class BooruService {
         const maybeKemonoClass = (UBW as any).Kemono
 
         if (!maybeKemonoClass) {
-          throw new Error(
+          throw new ServiceUnavailableException(
             'Kemono booru type requires @alejandroakbal/universal-booru-wrapper version that exports Kemono'
           )
         }
 
         return maybeKemonoClass
       }
+
+      default:
+        throw new BadRequestException(`Unsupported booru type: ${booruType}`)
     }
   }
 }

--- a/src/booru/booru.service.ts
+++ b/src/booru/booru.service.ts
@@ -16,8 +16,9 @@ import {
   Rule34PahealNet,
   Rule34Xxx
 } from '@alejandroakbal/universal-booru-wrapper'
+import * as UBW from '@alejandroakbal/universal-booru-wrapper'
 import { booruQueriesDTO } from './dto/booru-queries.dto'
-import { BooruEndpointParamsDTO } from './dto/request-booru.dto'
+import { BooruEndpointParamsDTO, SupportedBooruType } from './dto/request-booru.dto'
 import { BooruAuthManagerService } from './services/booru-auth-manager.service'
 
 @Injectable()
@@ -112,7 +113,7 @@ export class BooruService {
     return {}
   }
 
-  private getApiClassByType(booruType: BooruTypesStringEnum) {
+  private getApiClassByType(booruType: SupportedBooruType) {
     switch (booruType) {
       case BooruTypesStringEnum.DANBOORU:
         return Danbooru
@@ -140,6 +141,18 @@ export class BooruService {
 
       case BooruTypesStringEnum.REALBOORU_COM:
         return RealBooruCom
+
+      case 'kemono': {
+        const maybeKemonoClass = (UBW as any).Kemono
+
+        if (!maybeKemonoClass) {
+          throw new Error(
+            'Kemono booru type requires @alejandroakbal/universal-booru-wrapper version that exports Kemono'
+          )
+        }
+
+        return maybeKemonoClass
+      }
     }
   }
 }

--- a/src/booru/dto/request-booru.dto.ts
+++ b/src/booru/dto/request-booru.dto.ts
@@ -1,12 +1,16 @@
 import { BooruTypesStringEnum } from '@alejandroakbal/universal-booru-wrapper'
 import { IsDefined, IsIn, IsNotEmpty, IsString } from 'class-validator'
 
-const BooruTypesToArray = Object.values(BooruTypesStringEnum)
+const AdditionalBooruTypes = ['kemono'] as const
+
+export type SupportedBooruType = BooruTypesStringEnum | (typeof AdditionalBooruTypes)[number]
+
+const BooruTypesToArray = [...Object.values(BooruTypesStringEnum), ...AdditionalBooruTypes]
 
 export class BooruEndpointParamsDTO {
   @IsDefined()
   @IsNotEmpty()
   @IsString()
   @IsIn(BooruTypesToArray)
-  readonly booruType: BooruTypesStringEnum
+  readonly booruType: SupportedBooruType
 }


### PR DESCRIPTION
## Summary
- allow `kemono` through API booru-type validation for issue #92
- resolve the Kemono wrapper class at runtime with a clear compatibility error when the installed wrapper version does not export it yet
- add a focused service test that covers both supported and pre-release wrapper states

## Notes
- this API change is intended to land alongside the wrapper PR that adds `Kemono`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kemono is now supported as a booru type with dynamic resolution from an external source.

* **Bug Fixes**
  * Enhanced error handling with descriptive exception messages for unsupported booru types and missing Kemono sources.

* **Tests**
  * Added tests verifying Kemono resolution behavior and error handling for unavailable sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->