### PR TITLE
feat: allow proxy bypassing with 'NONE' string

### DIFF
--- a/src/booru/booru.service.spec.ts
+++ b/src/booru/booru.service.spec.ts
@@ -305,6 +305,34 @@ describe('BooruService', () => {
       expect(directUrl.searchParams.get('api_key')).toBe('pass_1')
     })
 
+    it('should allow bypassing proxies with the NONE magic string', () => {
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === 'BOORU_OUTBOUND_PROXY_CONFIG') {
+          return JSON.stringify({
+            'gelbooru.com': {
+              baseUrl: 'NONE'
+            }
+          })
+        }
+
+        return undefined
+      })
+
+      const queries = {
+        ...baseQueries,
+        baseEndpoint: 'gelbooru.com',
+        auth_user: 'managed_1',
+        auth_pass: 'pass_1'
+      } as booruQueriesDTO
+
+      const directUrl = buildPostUrl(service.buildApiClass(mockParams, queries))
+
+      expect(directUrl.origin).toBe('https://gelbooru.com')
+      expect(directUrl.searchParams.get('tags')).toBe('diana')
+      expect(directUrl.searchParams.get('user_id')).toBe('managed_1')
+      expect(directUrl.searchParams.get('api_key')).toBe('pass_1')
+    })
+
     it('should rotate through multiple configured provider proxies', () => {
       mockConfigService.get.mockImplementation((key: string) => {
         if (key === 'BOORU_OUTBOUND_PROXY_CONFIG') {
@@ -317,6 +345,9 @@ describe('BooruService', () => {
               {
                 baseUrl: 'https://cors-proxy.refinedsoftware00.workers.dev/',
                 targetParam: 'q'
+              },
+              {
+                baseUrl: 'NONE'
               }
             ]
           })
@@ -335,10 +366,12 @@ describe('BooruService', () => {
       const firstUrl = buildPostUrl(service.buildApiClass(mockParams, queries))
       const secondUrl = buildPostUrl(service.buildApiClass(mockParams, queries))
       const thirdUrl = buildPostUrl(service.buildApiClass(mockParams, queries))
+      const fourthUrl = buildPostUrl(service.buildApiClass(mockParams, queries))
 
       expect(firstUrl.origin).toBe('https://cors-proxy2.rule34.workers.dev')
       expect(secondUrl.origin).toBe('https://cors-proxy.refinedsoftware00.workers.dev')
-      expect(thirdUrl.origin).toBe('https://cors-proxy2.rule34.workers.dev')
+      expect(thirdUrl.origin).toBe('https://gelbooru.com')
+      expect(fourthUrl.origin).toBe('https://cors-proxy2.rule34.workers.dev')
     })
 
     it('should not rotate proxies while building an API that never fetches', () => {
@@ -353,6 +386,9 @@ describe('BooruService', () => {
               {
                 baseUrl: 'https://cors-proxy.refinedsoftware00.workers.dev/',
                 targetParam: 'q'
+              },
+              {
+                baseUrl: 'NONE'
               }
             ]
           })

--- a/src/booru/booru.service.ts
+++ b/src/booru/booru.service.ts
@@ -42,7 +42,7 @@ interface BooruQueryIdentifierDefaults {
 }
 
 interface BooruOutboundProxyPolicy {
-  baseUrl: string
+  baseUrl: string | 'NONE'
   targetParam: string
 }
 
@@ -421,7 +421,7 @@ export class BooruService {
         const upstreamUrl = originalMethod.apply(api, args) as URL
         const proxyPolicy = this.getOutboundProxyPolicy(domain)
 
-        if (proxyPolicy === undefined) {
+        if (proxyPolicy === undefined || proxyPolicy.baseUrl === 'NONE') {
           return upstreamUrl
         }
 
@@ -522,6 +522,10 @@ export class BooruService {
 
     const baseUrl = policy['baseUrl']
     const targetParam = policy['targetParam'] ?? 'q'
+
+    if (baseUrl === 'NONE') {
+      return { baseUrl, targetParam: 'q' }
+    }
 
     if (typeof baseUrl !== 'string' || !URL.canParse(baseUrl)) {
       throw new Error(`Invalid BOORU_OUTBOUND_PROXY_CONFIG baseUrl for ${domain}`)


### PR DESCRIPTION
- Added `'NONE'` as a valid magic string value for `baseUrl` in `BooruOutboundProxyPolicy`.
- Updated `validateOutboundProxyPolicy` to intercept `'NONE'` and avoid triggering normal URL validation checks.
- Modified the monkey-patched method interceptors inside `applyOutboundProxy` to check for `proxyPolicy.baseUrl === 'NONE'` and return the upstream URL natively without wrapping it in a proxy.
- Added comprehensive unit testing to `booru.service.spec.ts` to assert that proxy generation handles both bypass and rotating states seamlessly.

---
*PR created automatically by Jules for task [15659793156989340818](https://jules.google.com/task/15659793156989340818) started by @AlejandroAkbal*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for disabling outbound proxying for specific domains.
  * Requests configured to bypass the proxy now connect directly while retaining query and authentication parameters.
  * Proxy rotation continues correctly after a direct connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->