### PR TITLE
refactor(booru): remove redundant User-Agent branching and rely on UBW defaults

### DIFF
--- a/src/booru/booru.service.ts
+++ b/src/booru/booru.service.ts
@@ -190,13 +190,6 @@ export class BooruService {
       options.proxy = forwardProxy
     }
 
-    const domain = this.normalizeOutboundProxyDomain(queries.baseEndpoint)
-    if (domain === 'e621.net' || domain === 'e926.net') {
-      options.userAgent = 'r34-app/1.0 (by alejandro on e621)'
-    } else {
-      options.userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36'
-    }
-
     const Api = new booruClass(
       endpoints,
       defaultQueryIdentifiers as Partial<IBooruQueryIdentifiers>,


### PR DESCRIPTION
## Summary
- Cleans up `BooruService.buildApiWithContext` by removing redundant domain-specific User-Agent overrides.
- Relies on Universal-Booru-Wrapper to define compliant defaults natively.
- All unit tests and build pass cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated network request handling to stop applying a custom user-agent identity. This may improve compatibility with supported booru services and avoids sending an app-specific browser identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->