### PR TITLE
fix(sentry): filter upstream gateway and service unavailable errors

### DIFF
--- a/src/common/filters/sentry-exception.filter.spec.ts
+++ b/src/common/filters/sentry-exception.filter.spec.ts
@@ -1,0 +1,106 @@
+import type { ArgumentsHost } from '@nestjs/common'
+import {
+  BadGatewayException,
+  GatewayTimeoutException,
+  InternalServerErrorException,
+  NotFoundException,
+  ServiceUnavailableException
+} from '@nestjs/common'
+import type { HttpAdapterHost } from '@nestjs/core'
+import * as Sentry from '@sentry/nestjs'
+import { SentryExceptionFilter } from './sentry-exception.filter'
+
+jest.mock('@sentry/nestjs', () => ({
+  captureException: jest.fn()
+}))
+
+describe('SentryExceptionFilter', () => {
+  let filter: SentryExceptionFilter
+  let mockHttpAdapterHost: HttpAdapterHost
+  let mockArgumentsHost: ArgumentsHost
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockHttpAdapterHost = {
+      httpAdapter: {
+        reply: jest.fn(),
+        end: jest.fn(),
+        isHeadersSent: jest.fn().mockReturnValue(false),
+        setHeader: jest.fn(),
+        getRequestMethod: jest.fn().mockReturnValue('GET'),
+        getRequestUrl: jest.fn().mockReturnValue('/test')
+      }
+    } as unknown as HttpAdapterHost
+
+    mockArgumentsHost = {
+      switchToHttp: jest.fn().mockReturnValue({
+        getRequest: jest.fn().mockReturnValue({}),
+        getResponse: jest.fn().mockReturnValue({})
+      }),
+      getArgByIndex: jest.fn().mockReturnValue({}),
+      getArgs: jest.fn().mockReturnValue([{}, {}]),
+      getType: jest.fn().mockReturnValue('http')
+    } as unknown as ArgumentsHost
+
+    filter = new SentryExceptionFilter(mockHttpAdapterHost)
+  })
+
+  it('captures unhandled 500 InternalServerErrorException to Sentry', () => {
+    const error = new InternalServerErrorException('Database failure')
+
+    filter.catch(error, mockArgumentsHost)
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(error, {
+      mechanism: {
+        handled: false,
+        type: 'auto.http.nestjs.global_filter'
+      }
+    })
+  })
+
+  it('captures raw unhandled Error instances to Sentry', () => {
+    const error = new Error('Unexpected runtime crash')
+
+    filter.catch(error, mockArgumentsHost)
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(error, {
+      mechanism: {
+        handled: false,
+        type: 'auto.http.nestjs.global_filter'
+      }
+    })
+  })
+
+  it('ignores 4xx client errors (e.g. 404 NotFoundException)', () => {
+    const error = new NotFoundException('Resource not found')
+
+    filter.catch(error, mockArgumentsHost)
+
+    expect(Sentry.captureException).not.toHaveBeenCalled()
+  })
+
+  it('ignores upstream 502 BadGatewayException', () => {
+    const error = new BadGatewayException('Upstream booru returned 502')
+
+    filter.catch(error, mockArgumentsHost)
+
+    expect(Sentry.captureException).not.toHaveBeenCalled()
+  })
+
+  it('ignores upstream 503 ServiceUnavailableException', () => {
+    const error = new ServiceUnavailableException('Upstream booru is unavailable')
+
+    filter.catch(error, mockArgumentsHost)
+
+    expect(Sentry.captureException).not.toHaveBeenCalled()
+  })
+
+  it('ignores upstream 504 GatewayTimeoutException', () => {
+    const error = new GatewayTimeoutException('Upstream booru timed out')
+
+    filter.catch(error, mockArgumentsHost)
+
+    expect(Sentry.captureException).not.toHaveBeenCalled()
+  })
+})

--- a/src/common/filters/sentry-exception.filter.ts
+++ b/src/common/filters/sentry-exception.filter.ts
@@ -1,5 +1,7 @@
-import { ArgumentsHost, Catch, HttpException } from '@nestjs/common'
-import { BaseExceptionFilter, HttpAdapterHost } from '@nestjs/core'
+import type { ArgumentsHost } from '@nestjs/common'
+import { Catch, HttpException, HttpStatus } from '@nestjs/common'
+import type { HttpAdapterHost } from '@nestjs/core'
+import { BaseExceptionFilter } from '@nestjs/core'
 import * as Sentry from '@sentry/nestjs'
 
 @Catch()
@@ -22,6 +24,24 @@ export class SentryExceptionFilter extends BaseExceptionFilter {
   }
 
   private shouldCapture(exception: unknown): boolean {
-    return !(exception instanceof HttpException && exception.getStatus() < 500)
+    if (exception instanceof HttpException) {
+      const status = exception.getStatus()
+
+      // Ignore 4xx client errors
+      if (status < 500) {
+        return false
+      }
+
+      // Ignore upstream external gateway / booru service outages (502, 503, 504)
+      if (
+        status === Number(HttpStatus.BAD_GATEWAY) ||
+        status === Number(HttpStatus.SERVICE_UNAVAILABLE) ||
+        status === Number(HttpStatus.GATEWAY_TIMEOUT)
+      ) {
+        return false
+      }
+    }
+
+    return true
   }
 }

--- a/src/common/filters/sentry-exception.filter.ts
+++ b/src/common/filters/sentry-exception.filter.ts
@@ -1,8 +1,13 @@
 import type { ArgumentsHost } from '@nestjs/common'
 import { Catch, HttpException, HttpStatus } from '@nestjs/common'
-import type { HttpAdapterHost } from '@nestjs/core'
-import { BaseExceptionFilter } from '@nestjs/core'
+import { BaseExceptionFilter, HttpAdapterHost } from '@nestjs/core'
 import * as Sentry from '@sentry/nestjs'
+
+const UPSTREAM_OUTAGE_STATUSES: readonly number[] = [
+  HttpStatus.BAD_GATEWAY as number,
+  HttpStatus.SERVICE_UNAVAILABLE as number,
+  HttpStatus.GATEWAY_TIMEOUT as number
+]
 
 @Catch()
 export class SentryExceptionFilter extends BaseExceptionFilter {
@@ -27,17 +32,13 @@ export class SentryExceptionFilter extends BaseExceptionFilter {
     if (exception instanceof HttpException) {
       const status = exception.getStatus()
 
-      // Ignore 4xx client errors
+      // 4xx client errors are expected request rejections, not server defects
       if (status < 500) {
         return false
       }
 
-      // Ignore upstream external gateway / booru service outages (502, 503, 504)
-      if (
-        status === Number(HttpStatus.BAD_GATEWAY) ||
-        status === Number(HttpStatus.SERVICE_UNAVAILABLE) ||
-        status === Number(HttpStatus.GATEWAY_TIMEOUT)
-      ) {
+      // 502/503/504 upstream provider failures are external outages, not application bugs
+      if (UPSTREAM_OUTAGE_STATUSES.includes(status)) {
         return false
       }
     }


### PR DESCRIPTION
### Summary
- Exclude 502 (Bad Gateway), 503 (Service Unavailable), and 504 (Gateway Timeout) from Sentry exception capture in `SentryExceptionFilter`.
- Prevents upstream booru provider downtime (e.g. e621, rule34.xxx, gelbooru) from spamming Sentry as internal application crashes.
- Added comprehensive unit tests covering 500, unhandled Errors, 4xx ignores, and upstream 502/503/504 ignores.

### Verification
- Unit tests: 11/11 suites passed (103 tests).
- ESLint: 0 warnings, 0 errors.
- NestJS build: successful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error monitoring now excludes expected client errors and upstream gateway or service outage responses.
  * Other unhandled server errors continue to be captured with appropriate diagnostic context.

* **Tests**
  * Added coverage verifying which exceptions are captured and which are excluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->